### PR TITLE
Fix Linting errors on ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
   "rules": {
     "indent": [
       "error",
+      2,
       2
     ],
     "linebreak-style": [


### PR DESCRIPTION
We're implementing CodeClimate, and this isn't setup correctly. This helps the linter know what to do when checking for tabs that are longer than two spaces.
