### PR TITLE
Fix linting error with ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,26 +9,10 @@
     "sourceType": "module"
   },
   "rules": {
-    "indent": [
-      "error",
-      2
-    ],
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
-    "quotes": [
-      "error",
-      "single"
-    ],
-    "semi": [
-      "error",
-      "always"
-    ],
-    "max-len": [
-      "error",
-      100,
-      2
-    ]
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "single"],
+    "semi": ["error", "always"],
+    "max-len": ["error", 100, 2]
   }
 }


### PR DESCRIPTION
We're implementing CodeClimate, and this isn't setup correctly. This helps the linter know what to do when checking for tabs that are longer than two spaces.
