### PR TITLE
Fix Webpage README URL

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -19,7 +19,7 @@ html
             h5.caption!= caption
         .row
             .col.m3.s12.spaced
-                a.waves-effect.waves-light.btn.orange(href='https://github.com/devacademyla/PiscoBot/README.md')= 'About'
+                a.waves-effect.waves-light.btn.orange(href='https://github.com/devacademyla/PiscoBot/blob/master/README.md')= 'About'
             .col.m3.s12.spaced
                 a.waves-effect.waves-light.btn.orange(href='https://github.com/devacademyla/PiscoBot/wiki/')= 'Documentation'
             .col.m3.s12.spaced


### PR DESCRIPTION
GitHub's URLs are kinda weird, man, okay? Sue me. 

This fixes the error in the webpage that currently 404s.
